### PR TITLE
[main] Update app baselines package version. New value: 24.3.20605.0 (+ 1 more update(s))

### DIFF
--- a/build/Packages.json
+++ b/build/Packages.json
@@ -1,10 +1,10 @@
 {
   "Microsoft.Dynamics.BusinessCentral.Translations": {
-    "Version": "25.0.20240603.4",
+    "Version": "25.0.20240610.3",
     "Source": "NuGet.org"
   },
   "AppBaselines-BCArtifacts": {
-    "Version": "24.3.20365.0",
+    "Version": "24.3.20605.0",
     "Source": "BCArtifacts",
     "_comment": "Used to fetch app baselines from BC artifacts"
   }


### PR DESCRIPTION
This PR contains the following changes:
- Update app baselines package version. New value: 24.3.20605.0
- Update translation package version. New value: 25.0.20240610.3

Fixes AB#420000.