### PR TITLE
[24.x] Update app baselines package version. New value: 24.2.20227.21176 (+ 1 more update(s))

### DIFF
--- a/build/Packages.json
+++ b/build/Packages.json
@@ -1,10 +1,10 @@
 {
   "Microsoft.Dynamics.BusinessCentral.Translations": {
-    "Version": "24.3.20240618.3",
+    "Version": "24.3.20240625.3",
     "Source": "NuGet.org"
   },
   "AppBaselines-BCArtifacts": {
-    "Version": "24.2.20227.20903",
+    "Version": "24.2.20227.21176",
     "Source": "BCArtifacts",
     "_comment": "Used to fetch app baselines from BC artifacts"
   }


### PR DESCRIPTION
This PR contains the following changes:
- Update app baselines package version. New value: 24.2.20227.21176
- Update translation package version. New value: 24.3.20240625.3

Fixes AB#420000.