### PR TITLE
[main] Update AL-Go System Files from microsoft/AL-Go-PTE@preview -  4fd6c113536be76423b0eafc1b60e0ea8d077042

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -73,5 +73,5 @@
     ]
   },
   "UpdateALGoSystemFilesEnvironment": "Official-Build",
-  "templateSha": "6d77148c1f6eb4bde3f4a4b1d47443b233c7595d"
+  "templateSha": "4fd6c113536be76423b0eafc1b60e0ea8d077042"
 }

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -5,7 +5,7 @@
   "runs-on": "windows-latest",
   "cacheImageName": "",
   "UsePsSession": false,
-  "artifact": "https://bcinsider-fvh2ekdjecfjd6gk.b02.azurefd.net/sandbox/25.0.22637.0/base",
+  "artifact": "bcartifacts/Sandbox/25.0/base/latest",
   "country": "base",
   "useProjectDependencies": true,
   "repoVersion": "25.0",

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -32,6 +32,10 @@ In the summary after a Test Run, you now also have the result of performance tes
 Previously, the workflows "Update AL-Go System Files" and "TroubleShooting" were hardcoded to always run on `windows-latest` to prevent deadlocks and security issues.
 From now on, `ubuntu-lates` will also be allowed for these mission critical workflows, when changing the `runs-on` setting. Additionally, only the value `pwsh` for `shell` setting is allowed when using `ubuntu-latest` runners.
 
+### Updated AL-Go telemetry
+
+AL-Go for GitHub now includes a new telemetry module. For detailed information on how to enable or disable telemetry and to see what data AL-Go logs, check out [this article](https://github.com/microsoft/AL-Go/blob/main/Scenarios/EnablingTelemetry.md).
+
 ### New Settings
 
 - `deployTo<environmentName>`: is not really new, but has a new property:

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -14,10 +14,10 @@ defaults:
     shell: powershell
 
 permissions:
-  contents: read
   actions: read
-  pages: read
+  contents: read
   id-token: write
+  pages: read
 
 env:
   workflowDepth: 2
@@ -45,7 +45,7 @@ jobs:
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
 
@@ -56,14 +56,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
-          eventId: "DO0091"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSettings@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           get: type, powerPlatformSolutionFolder
@@ -75,7 +74,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -88,7 +87,7 @@ jobs:
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -96,7 +95,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSecrets@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -104,7 +103,7 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -114,7 +113,7 @@ jobs:
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -130,13 +129,13 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSettings@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           get: templateUrl
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           templateUrl: ${{ env.templateUrl }}
@@ -155,7 +154,6 @@ jobs:
     with:
       shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
       runsOn: ${{ needs.Initialization.outputs.githubRunner }}
-      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
       project: ${{ matrix.project }}
       projectName: ${{ matrix.projectName }}
       buildMode: ${{ matrix.buildMode }}
@@ -179,7 +177,6 @@ jobs:
     with:
       shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
       runsOn: ${{ needs.Initialization.outputs.githubRunner }}
-      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
       project: ${{ matrix.project }}
       projectName: ${{ matrix.projectName }}
       buildMode: ${{ matrix.buildMode }}
@@ -213,7 +210,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSettings@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
 
@@ -222,7 +219,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           artifacts: '.artifacts'
@@ -259,7 +256,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSettings@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
@@ -273,7 +270,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSecrets@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -281,7 +278,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go/Actions/Deploy@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/Deploy@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -293,7 +290,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -321,20 +318,20 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSettings@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSecrets@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go/Actions/Deliver@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/Deliver@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -354,8 +351,10 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           shell: powershell
-          eventId: "DO0091"
           telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          currentJobContext: ${{ toJson(job) }}

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
   actions: read
-  pages: write
+  contents: read
   id-token: write
+  pages: write
 
 defaults:
   run:
@@ -30,19 +30,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
-          eventId: "DO0097"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSettings@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -55,7 +54,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           artifacts: 'latest'
@@ -69,3 +68,13 @@ jobs:
         if: steps.DetermineDeploymentEnvironments.outputs.deployALDocArtifact == 1
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+
+      - name: Finalize the workflow
+        if: always()
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          shell: powershell
+          telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          currentJobContext: ${{ toJson(job) }}

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -22,9 +22,10 @@ on:
         default: false
 
 permissions:
+  actions: read
   contents: write
-  pull-requests: write
   id-token: write
+  pull-requests: write
 
 defaults:
   run:
@@ -40,7 +41,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
 
@@ -49,19 +50,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
-          eventId: "DO0096"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSettings@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSecrets@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -69,19 +69,20 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           projects: ${{ github.event.inputs.projects }}
           versionNumber: ${{ github.event.inputs.versionNumber }}
           directCommit: ${{ github.event.inputs.directCommit }}
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           shell: powershell
-          eventId: "DO0096"
           telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          currentJobContext: ${{ toJson(job) }}

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -13,10 +13,10 @@ defaults:
     shell: powershell
 
 permissions:
-  contents: read
   actions: read
-  pull-requests: read
+  contents: read
   id-token: write
+  pull-requests: read
 
 env:
   workflowDepth: 2
@@ -28,14 +28,13 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: windows-latest
     steps:
-      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
 
   Initialization:
     needs: [ PregateCheck ]
     if: (!failure() && !cancelled())
     runs-on: [ windows-latest ]
     outputs:
-      telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
       githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
       projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
@@ -43,9 +42,10 @@ jobs:
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
       baselineWorkflowRunId: ${{ steps.determineProjectsToBuild.outputs.BaselineWorkflowRunId }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
+      telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
 
@@ -57,14 +57,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
-          eventId: "DO0104"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSettings@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
 
@@ -75,7 +74,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -94,7 +93,6 @@ jobs:
       shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
       runsOn: ${{ needs.Initialization.outputs.githubRunner }}
       checkoutRef: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/{0}/merge', github.event.pull_request.number) }}
-      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
       project: ${{ matrix.project }}
       projectName: ${{ matrix.projectName }}
       buildMode: ${{ matrix.buildMode }}
@@ -118,7 +116,6 @@ jobs:
       shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
       runsOn: ${{ needs.Initialization.outputs.githubRunner }}
       checkoutRef: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/{0}/merge', github.event.pull_request.number) }}
-      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
       project: ${{ matrix.project }}
       projectName: ${{ matrix.projectName }}
       buildMode: ${{ matrix.buildMode }}
@@ -136,8 +133,18 @@ jobs:
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           shell: powershell
+
+      - name: Finalize the workflow
+        id: PostProcess
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          shell: powershell
+          telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          currentJobContext: ${{ toJson(job) }}

--- a/.github/workflows/SubmitStabilityJobs.yaml
+++ b/.github/workflows/SubmitStabilityJobs.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Submit Stability Job
         env:
           GH_TOKEN: ${{ secrets.GHTOKENWORKFLOW }}
-        uses: microsoft/BCApps/.github/actions/RunAutomation@main
+        uses: aholstrup1/BCApps/.github/actions/RunAutomation@main
         with:
           automations: SubmitStabilityJob
           targetBranch: ${{ matrix.branch }}

--- a/.github/workflows/SubmitStabilityJobs.yaml
+++ b/.github/workflows/SubmitStabilityJobs.yaml
@@ -9,7 +9,6 @@ permissions: read-all
 
 jobs:
   GetBranches:
-    if: github.repository_owner == 'microsoft'
     name: Get Official Branches
     runs-on: ubuntu-latest
     outputs:
@@ -22,7 +21,6 @@ jobs:
           include: "['main', 'releases/*']"
 
   SubmitStabilityJobs:
-    if: github.repository_owner == 'microsoft'
     name: "[${{ matrix.branch }}] Submit Stability Job"
     runs-on: ubuntu-latest
     environment: Official-Build

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -9,8 +9,8 @@ on:
         default: false
 
 permissions:
-  contents: read
   actions: read
+  contents: read
 
 defaults:
   run:
@@ -30,7 +30,7 @@ jobs:
           lfs: true
 
       - name: Troubleshooting
-        uses: microsoft/AL-Go/Actions/Troubleshooting@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/Troubleshooting@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}

--- a/.github/workflows/UpdateBCArtifactVersion.yaml
+++ b/.github/workflows/UpdateBCArtifactVersion.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Update BC Artifact Version
         env:
           GH_TOKEN: ${{ secrets.GHTOKENWORKFLOW }}
-        uses: microsoft/BCApps/.github/actions/RunAutomation@main
+        uses: aholstrup1/BCApps/.github/actions/RunAutomation@main
 
         with:
           automations: UpdateBCArtifact

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -17,6 +17,7 @@ on:
         default: false
 
 permissions:
+  actions: read
   contents: read
   id-token: write
 
@@ -36,7 +37,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
 
@@ -45,20 +46,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
-          eventId: "DO0098"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSettings@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSecrets@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -94,7 +94,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: powershell
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
@@ -105,8 +105,10 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           shell: powershell
-          eventId: "DO0098"
           telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          currentJobContext: ${{ toJson(job) }}

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -67,14 +67,10 @@ on:
         description: Flag determining whether to use the Artifacts Cache
         type: boolean
         default: false
-      parentTelemetryScopeJson:
-        description: Specifies the telemetry scope for the telemetry signal
-        required: false
-        type: string
 
 permissions:
-  contents: read
   actions: read
+  contents: read
   id-token: write
 
 env:
@@ -97,7 +93,7 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSettings@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -106,18 +102,17 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: github.event_name != 'pull_request'
-        uses: microsoft/AL-Go/Actions/ReadSecrets@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/ReadSecrets@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ inputs.secrets }},appDependencyProbingPathsSecrets,AZURE_CREDENTIALS'
 
       - name: Determine ArtifactUrl
-        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         id: determineArtifactUrl
         with:
           shell: ${{ inputs.shell }}
-          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
           project: ${{ inputs.project }}
 
       - name: Cache Business Central Artifacts
@@ -129,7 +124,7 @@ jobs:
 
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
-        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -140,13 +135,12 @@ jobs:
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
       - name: Build
-        uses: microsoft/AL-Go/Actions/RunPipeline@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/RunPipeline@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           BuildMode: ${{ inputs.buildMode }}
         with:
           shell: ${{ inputs.shell }}
-          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
           artifact: ${{ env.artifact }}
           project: ${{ inputs.project }}
           buildMode: ${{ inputs.buildMode }}
@@ -156,16 +150,15 @@ jobs:
       - name: Sign
         if: inputs.signArtifacts && env.doNotSignApps == 'False' && env.keyVaultCodesignCertificateName != ''
         id: sign
-        uses: microsoft/AL-Go/Actions/Sign@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/Sign@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
           pathToFiles: '${{ inputs.project }}/.buildartifacts/Apps/*.app'
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -259,16 +252,14 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: ${{ inputs.shell }}
-          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
           project: ${{ inputs.project }}
 
       - name: Cleanup
         if: always()
-        uses: microsoft/AL-Go/Actions/PipelineCleanup@381a1e2d859ecafd242ca80a45449caf3c8b7fd5
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080
         with:
           shell: ${{ inputs.shell }}
-          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
           project: ${{ inputs.project }}

--- a/build/projects/AI Test Toolkit/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/AI Test Toolkit/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/AI Test Toolkit/.AL-Go/localDevEnv.ps1
+++ b/build/projects/AI Test Toolkit/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Framework/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Test Framework/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Framework/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Test Framework/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/381a1e2d859ecafd242ca80a45449caf3c8b7fd5/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/6e2d05ca0fcb62e51e403cbd0539c6b1ad7f3080/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local


### PR DESCRIPTION
## preview

Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.

### Issues

- Issue 1105 Increment Version Number - repoVersion in .github/AL-Go-Settings.json is not updated
- Issue 1073 Publish to AppSource - Automated validation: failure
- Issue 980 Allow Scope to be PTE in continuousDeployment for PTE extensions in Sandbox (enhancement request)
- Issue 1079 AppSource App deployment failes with PerTenantExtensionCop Error PTE0001 and PTE0002
- Issue 866 Accessing GitHub Environment Variables in DeployToCustom Scenarios for PowerShell Scripts
- Issue 1083 SyncMode for custom deployments?
- Issue 1109 Why filter deployment settings?
- Fix issue with github ref when running reusable workflows
- Issue 1098 Support for specifying the name of the AZURE_CREDENTIALS secret by adding a AZURE_CREDENTIALSSecretName setting
- Fix placeholder syntax for git ref in PullRequestHandler.yaml

### Dependencies to PowerShell modules

AL-Go for GitHub relies on specific PowerShell modules, and the minimum versions required for these modules are tracked in [Packages.json](https://raw.githubusercontent.com/microsoft/AL-Go/main/Actions/Packages.json) file. Should the installed modules on the GitHub runner not meet these minimum requirements, the necessary modules will be installed as needed.

### Support managed identities and federated credentials

All authentication context secrets now supports managed identities and federated credentials. See more [here](Scenarios/secrets.md). Furthermore, you can now use https://aka.ms/algosecrets#authcontext to learn more about the formatting of that secret.

### Business Central Performance Toolkit Test Result Viewer

In the summary after a Test Run, you now also have the result of performance tests.

### Support Ubuntu runners for all AL-Go workflows

Previously, the workflows "Update AL-Go System Files" and "TroubleShooting" were hardcoded to always run on `windows-latest` to prevent deadlocks and security issues.
From now on, `ubuntu-lates` will also be allowed for these mission critical workflows, when changing the `runs-on` setting. Additionally, only the value `pwsh` for `shell` setting is allowed when using `ubuntu-latest` runners.

### Updated AL-Go telemetry

AL-Go for GitHub now includes a new telemetry module. For detailed information on how to enable or disable telemetry and to see what data AL-Go logs, check out [this article](https://github.com/microsoft/AL-Go/blob/main/Scenarios/EnablingTelemetry.md).

### New Settings

- `deployTo<environmentName>`: is not really new, but has a new property:

  - **Scope** = specifies the scope of the deployment: Dev, PTE. If not specified, AL-Go for GitHub will always use the Dev Scope for AppSource Apps, but also for PTEs when deploying to sandbox environments when impersonation (refreshtoken) is used for authentication.
  - **BuildMode** = specifies which buildMode to use for the deployment. Default is to use the Default buildMode.
  - **\<custom>** = custom properties are now supported and will be transferred to a custom deployment script in the hashtable.

- `bcptThresholds` is a JSON object with properties for the default thresholds for the Business Central Performance Toolkit

  - **DurationWarning** - a warning is issued if the duration of a bcpt test degrades more than this percentage (default 10)
  - **DurationError** - an error is issued if the duration of a bcpt test degrades more than this percentage (default 25)
  - **NumberOfSqlStmtsWarning** - a warning is issued if the number of SQL statements from a bcpt test increases more than this percentage (default 5)
  - **NumberOfSqlStmtsError** - an error is issued if the number of SQL statements from a bcpt test increases more than this percentage (default 10)

> \[!NOTE\]
> Duration thresholds are subject to varying results depending on the performance of the agent running the tests. Number of SQL statements executed by a test is often the most reliable indicator of performance degredation.
