### PR TITLE
Demo: System Application code-scanning alert (DO NOT MERGE)

### DIFF
--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -167,7 +167,7 @@ jobs:
       - name: Process AL Code Analysis Logs
         id: ProcessALCodeAnalysisLogs
         if: (success() || failure())
-        uses: microsoft/AL-Go/Actions/ProcessALCodeAnalysisLogs@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: aholstrup1/AL-Go/Actions/ProcessALCodeAnalysisLogs@aholstrup1-track-al-alerts-workspace-compilation
         with:
           shell: powershell
 

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
@@ -141,16 +141,4 @@ codeunit 7768 "AOAI Deployments"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         exit(AOAIDeploymentsImpl.GetGPT53ChatPreview(CallerModuleInfo));
     end;
-
-    /// <summary>
-    /// Intentional demo warning: an unused local variable (CodeCop AA0137) plus an unreachable
-    /// statement after exit, both reported by the AL compiler as located WARNINGs. DO NOT MERGE.
-    /// </summary>
-    local procedure DemoCodeScanningWarning()
-    var
-        DemoUnusedVariable: Integer;
-    begin
-        exit;
-        exit;
-    end;
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
@@ -141,4 +141,16 @@ codeunit 7768 "AOAI Deployments"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         exit(AOAIDeploymentsImpl.GetGPT53ChatPreview(CallerModuleInfo));
     end;
+
+    /// <summary>
+    /// Intentional demo warning: an unused local variable (CodeCop AA0137) plus an unreachable
+    /// statement after exit, both reported by the AL compiler as located WARNINGs. DO NOT MERGE.
+    /// </summary>
+    local procedure DemoCodeScanningWarning()
+    var
+        DemoUnusedVariable: Integer;
+    begin
+        exit;
+        exit;
+    end;
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIToken.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIToken.Codeunit.al
@@ -66,10 +66,16 @@ codeunit 7759 "AOAI Token"
         exit(AzureOpenAIImpl.GetTotalServerSessionTokensConsumed());
     end;
     /// <summary>
-    /// Intentional demo error to showcase AL code scanning alerts. DO NOT MERGE.
+    /// Intentional demo code scanning triggers to showcase AL code scanning alerts. DO NOT MERGE.
+    /// Emits an ERROR (unused variable -> AA0137, Error via ruleset generalAction) and a
+    /// WARNING (value assigned but never read -> AA0206, Warning). Both are valid, compilable AL,
+    /// so the analyzer pass completes and reports both located diagnostics.
     /// </summary>
-    procedure DemoCodeScanningError()
+    procedure DemoCodeScanning()
+    var
+        DemoUnusedVariable: Integer;
+        DemoAssignedNeverRead: Integer;
     begin
-        UndefinedDemoVariable := 1;
+        DemoAssignedNeverRead := 1;
     end;
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIToken.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIToken.Codeunit.al
@@ -65,4 +65,11 @@ codeunit 7759 "AOAI Token"
     begin
         exit(AzureOpenAIImpl.GetTotalServerSessionTokensConsumed());
     end;
+    /// <summary>
+    /// Intentional demo error to showcase AL code scanning alerts. DO NOT MERGE.
+    /// </summary>
+    procedure DemoCodeScanningError()
+    begin
+        UndefinedDemoVariable := 1;
+    end;
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIToken.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIToken.Codeunit.al
@@ -74,18 +74,14 @@ codeunit 7759 "AOAI Token"
     end;
 
     /// <summary>
-    /// Intentional demo obsolete target to force an AL code scanning WARNING at its call site. DO NOT MERGE.
-    /// </summary>
-    [Obsolete('Intentional demo obsolete member for code scanning warning. DO NOT MERGE.', '1.0')]
-    procedure DemoObsoleteTarget()
-    begin
-    end;
-
-    /// <summary>
-    /// Intentional demo warning (references an obsolete member) to showcase AL code scanning alerts. DO NOT MERGE.
+    /// Intentional demo warning: the statement after exit is unreachable, which the AL compiler
+    /// reports as a WARNING (located in this file). DO NOT MERGE.
     /// </summary>
     procedure DemoCodeScanningWarning()
+    var
+        DemoUnreachable: Integer;
     begin
-        DemoObsoleteTarget();
+        exit;
+        DemoUnreachable := 1;
     end;
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIToken.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIToken.Codeunit.al
@@ -72,16 +72,4 @@ codeunit 7759 "AOAI Token"
     begin
         UndefinedDemoVariable := 1;
     end;
-
-    /// <summary>
-    /// Intentional demo warning: the statement after exit is unreachable, which the AL compiler
-    /// reports as a WARNING (located in this file). DO NOT MERGE.
-    /// </summary>
-    procedure DemoCodeScanningWarning()
-    var
-        DemoUnreachable: Integer;
-    begin
-        exit;
-        DemoUnreachable := 1;
-    end;
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIToken.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIToken.Codeunit.al
@@ -72,4 +72,20 @@ codeunit 7759 "AOAI Token"
     begin
         UndefinedDemoVariable := 1;
     end;
+
+    /// <summary>
+    /// Intentional demo obsolete target to force an AL code scanning WARNING at its call site. DO NOT MERGE.
+    /// </summary>
+    [Obsolete('Intentional demo obsolete member for code scanning warning. DO NOT MERGE.', '1.0')]
+    procedure DemoObsoleteTarget()
+    begin
+    end;
+
+    /// <summary>
+    /// Intentional demo warning (references an obsolete member) to showcase AL code scanning alerts. DO NOT MERGE.
+    /// </summary>
+    procedure DemoCodeScanningWarning()
+    begin
+        DemoObsoleteTarget();
+    end;
 }


### PR DESCRIPTION
**Demo PR — DO NOT MERGE.**

Purpose: show how AL code-scanning alerts render in the **Security** tab, and validate the SARIF invalid-URI fix on a spaced path.

Changes:
- Intentional compile error in `src/System Application/App/AI/src/Azure OpenAI/AOAIToken.Codeunit.al` (references an undefined identifier `UndefinedDemoVariable`). The file path contains a space (`System Application`), so it also exercises the per-segment URI-encoding fix.
- Point the PR build's `ProcessALCodeAnalysisLogs` at the fixed fork (`aholstrup1/AL-Go@aholstrup1-track-al-alerts-workspace-compilation`) so the PR path gets the URI fix (CompileApps already did).

Expected: PR build compiles System Application, emits the error into `errorLog.json` → SARIF (URI-encoded) → uploaded to code scanning → alert visible on this PR / Security tab, with no `is not a valid URI` warnings.